### PR TITLE
Use space-pen dependencies for input views

### DIFF
--- a/lib/ex-command-mode-input-view.coffee
+++ b/lib/ex-command-mode-input-view.coffee
@@ -1,4 +1,5 @@
-{View, TextEditorView} = require 'atom'
+{View} = require 'space-pen'
+{TextEditorView} = require 'atom-space-pen-views'
 
 module.exports =
 class ExCommandModeInputView extends View

--- a/package.json
+++ b/package.json
@@ -13,7 +13,9 @@
   },
   "dependencies": {
     "underscore-plus": "1.x",
-    "event-kit": "^0.7.2"
+    "event-kit": "^0.7.2",
+    "space-pen": "^5.1.1",
+    "atom-space-pen-views": "^2.0.4"
   },
   "consumedServices": {
     "vim-mode": {


### PR DESCRIPTION
Use SpacePen Views. TextEditorView, View exports from the atom module are deprecated.

fixes #19 