### PR TITLE
Fix consumeVim version so we can use it

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "consumedServices": {
     "vim-mode": {
       "versions": {
-        "^0.33.0": "consumeVim"
+        "^0.1.0": "consumeVim"
       }
     }
   },


### PR DESCRIPTION
[vim-mode](https://github.com/atom/vim-mode) only provides provideVimMode in version 0.1.0.

Fixes #2, I suppose.