### PR TITLE
Implement parsing following ex spec and :s, fix behaviour of :e

### DIFF
--- a/lib/command-error.coffee
+++ b/lib/command-error.coffee
@@ -1,0 +1,5 @@
+class CommandError
+  constructor: (@message) ->
+    @name = 'Command Error'
+
+module.exports = CommandError

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -147,7 +147,7 @@ class Command
       [m, command, args] = cl.match(/^(\w+)(.*)/)
 
     # If the command matches an existing one exactly, execute that one
-    if func = Ex.singleton()[command]?
+    if (func = Ex.singleton()[command])?
       func(range, args)
     else
       # Step 8: Match command against existing commands

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -1,5 +1,6 @@
 ExViewModel = require './ex-view-model'
 Ex = require './ex'
+Find = require './find'
 
 class CommandError
   constructor: (@message) ->
@@ -9,9 +10,124 @@ class Command
   constructor: (@editor, @exState) ->
     @viewModel = new ExViewModel(@)
 
+  parseAddr: (str, curLine) ->
+    if str == '.'
+      addr = curLine
+    else if str == '$'
+      # Lines are 0-indexed in Atom, but 1-indexed in vim.
+      addr = @editor.getBuffer().lines.length - 1
+    else if str[0] in ["+", "-"]
+      addr = curLine + @parseOffset(str)
+    else if not isNaN(str)
+      addr = parseInt(str) - 1
+    else if str[0] == "'" # Parse Mark...
+      unless @vimState?
+        throw new CommandError("Couldn't get access to vim-mode.")
+      mark = @vimState.marks[str[1]]
+      unless mark?
+        throw new CommandError('Mark ' + str + ' not set.')
+      addr = mark.bufferMarker.range.end.row
+    else if str[0] == "/" # TODO: Parse forward search
+      addr = Find.findNext(@editor.buffer.lines, str[1...-1], curLine)
+      unless addr?
+        throw new CommandError('Pattern not found: ' + str[1...-1])
+    else if str[0] == "?" # TODO: Parse backwards search
+      addr = Find.findPrevious(@editor.buffer.lines, str[1...-1], curLine)
+      unless addr?
+        throw new CommandError('Pattern not found: ' + str[1...-1])
+
+    return addr
+
+  parseOffset: (str) ->
+    if str.length == 0
+      return 0
+    if str.length == 1
+      o = 1
+    else
+      o = parseInt(str[1..])
+    if str[0] == '+'
+      return o
+    else
+      return -o
+
   execute: (input) ->
-    return unless input.characters.length > 0
-    [command, args...] = input.characters.split(" ")
+    @vimState = @exState.globalExState.vim?.getEditorState(@editor)
+    # Command line parsing (mostly) following the rules at
+    # http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#tag_20_40_13_03
+    # Steps 1/2: Leading blanks and colons are ignored.
+    cl = input.characters
+    cl = cl.replace(/^(:|\s)*/, '')
+    return unless cl.length > 0
+    # Step 3: If the first character is a ", ignore the rest of the line
+    if cl[0] == '"'
+      return
+    # Step 4: Address parsing
+    lastLine = @editor.getBuffer().lines.length - 1
+    if cl[0] == '%'
+      range = [0, lastLine]
+      cl = cl[1..]
+    else
+      addrPattern = ///^
+        (?:                               # First address
+        (
+        \.|                               # Current line
+        \$|                               # Last line
+        \d+|                              # n-th line
+        '[\[\]<>'`"^.(){}a-zA-Z]|         # Marks
+        /.*?[^\\]/|                       # Regex
+        \?.*?[^\\]\?|                     # Backwards search
+        [+-]\d*                           # Current line +/- a number of lines
+        )((?:\s*[+-]\d*)*)                # Line offset
+        )?
+        (?:,                              # Second address
+        (                                 # Same as first address
+        \.|
+        \$|
+        \d+|
+        '[\[\]<>'`"^.(){}a-zA-Z]|
+        /.*?[^\\]/|
+        \?.*?[^\\]\?|
+        [+-]\d*
+        )((?:\s*[+-]\d*)*)
+        )?
+      ///
+
+      [match, addr1, off1, addr2, off2] = cl.match(addrPattern)
+
+      curLine = @editor.getCursorBufferPosition().row
+
+      if addr1?
+        address1 = @parseAddr(addr1, curLine)
+      else
+        # If no addr1 is given (,+3), assume it is '.'
+        address1 = curLine
+      if off1?
+        address1 += @parseOffset(off1)
+
+      if address1 < 0 or address1 > lastLine
+        throw new CommandError('Invalid range')
+
+      if addr2?
+        address2 = @parseAddr(addr2, curLine)
+      if off2?
+        address2 += @parseOffset(off2)
+
+      if address2 < 0 or address2 > lastLine
+        throw new CommandError('Invalid range')
+
+      if address2 < address1
+        throw new CommandError('Backwards range given')
+
+      range = [address1, if address2? then address2 else address1]
+      cl = cl[match?.length..]
+
+    # Step 5: Leading blanks are ignored
+    cl = cl.trimLeft()
+
+    # Vim behavior: If no command is specified, go to the specified length
+    if cl.length == 0
+      @editor.setCursorBufferPosition([range[1], 0])
+      return
 
     func = Ex.singleton()[command]
     if func?

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -11,27 +11,27 @@ class Command
     @viewModel = new ExViewModel(@)
 
   parseAddr: (str, curLine) ->
-    if str == '.'
+    if str is '.'
       addr = curLine
-    else if str == '$'
+    else if str is '$'
       # Lines are 0-indexed in Atom, but 1-indexed in vim.
       addr = @editor.getBuffer().lines.length - 1
     else if str[0] in ["+", "-"]
       addr = curLine + @parseOffset(str)
     else if not isNaN(str)
       addr = parseInt(str) - 1
-    else if str[0] == "'" # Parse Mark...
+    else if str[0] is "'" # Parse Mark...
       unless @vimState?
         throw new CommandError("Couldn't get access to vim-mode.")
       mark = @vimState.marks[str[1]]
       unless mark?
         throw new CommandError('Mark ' + str + ' not set.')
       addr = mark.bufferMarker.range.end.row
-    else if str[0] == "/"
+    else if str[0] is "/"
       addr = Find.findNext(@editor.buffer.lines, str[1...-1], curLine)
       unless addr?
         throw new CommandError('Pattern not found: ' + str[1...-1])
-    else if str[0] == "?"
+    else if str[0] is "?"
       addr = Find.findPrevious(@editor.buffer.lines, str[1...-1], curLine)
       unless addr?
         throw new CommandError('Pattern not found: ' + str[1...-1])
@@ -39,13 +39,13 @@ class Command
     return addr
 
   parseOffset: (str) ->
-    if str.length == 0
+    if str.length is 0
       return 0
-    if str.length == 1
+    if str.length is 1
       o = 1
     else
       o = parseInt(str[1..])
-    if str[0] == '+'
+    if str[0] is '+'
       return o
     else
       return -o
@@ -60,11 +60,11 @@ class Command
     cl = cl.replace(/^(:|\s)*/, '')
     return unless cl.length > 0
     # Step 3: If the first character is a ", ignore the rest of the line
-    if cl[0] == '"'
+    if cl[0] is '"'
       return
     # Step 4: Address parsing
     lastLine = @editor.getBuffer().lines.length - 1
-    if cl[0] == '%'
+    if cl[0] is '%'
       range = [0, lastLine]
       cl = cl[1..]
     else
@@ -126,7 +126,7 @@ class Command
     cl = cl.trimLeft()
 
     # Step 6a: If no command is specified, go to the last specified address
-    if cl.length == 0
+    if cl.length is 0
       @editor.setCursorBufferPosition([range[1], 0])
       return
 
@@ -137,7 +137,7 @@ class Command
 
     # Step 7b: :k<valid mark> is equal to :mark <valid mark> - only a-zA-Z is
     # in vim-mode for now
-    if cl.length == 2 and cl[0] == 'k' and /[a-z]/i.test(cl[1])
+    if cl.length is 2 and cl[0] is 'k' and /[a-z]/i.test(cl[1])
       command = 'mark'
       args = cl[1]
     else if not /[a-z]/i.test(cl[0])
@@ -152,7 +152,7 @@ class Command
     else
       # Step 8: Match command against existing commands
       matching = ([name for name, val of Ex.singleton() when \
-        name.indexOf(command) == 0])
+        name.indexOf(command) is 0])
 
       matching.sort()
 

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -1,10 +1,7 @@
 ExViewModel = require './ex-view-model'
 Ex = require './ex'
 Find = require './find'
-
-class CommandError
-  constructor: (@message) ->
-    @name = 'Command Error'
+CommandError = require './command-error'
 
 class Command
   constructor: (@editor, @exState) ->
@@ -164,4 +161,4 @@ class Command
       else
         throw new CommandError("Not an editor command: #{input.characters}")
 
-module.exports = {Command, CommandError}
+module.exports = Command

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -151,8 +151,8 @@ class Command
       func(range, args)
     else
       # Step 8: Match command against existing commands
-      matching = ([name for name, val of Ex.singleton() when \
-        name.indexOf(command) is 0])
+      matching = (name for name, val of Ex.singleton() when \
+        name.indexOf(command) is 0)
 
       matching.sort()
 

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -25,16 +25,16 @@ class Command
         throw new CommandError("Couldn't get access to vim-mode.")
       mark = @vimState.marks[str[1]]
       unless mark?
-        throw new CommandError('Mark ' + str + ' not set.')
+        throw new CommandError("Mark #{str} not set.")
       addr = mark.bufferMarker.range.end.row
     else if str[0] is "/"
       addr = Find.findNextInBuffer(@editor.buffer, curPos, str[1...-1])
       unless addr?
-        throw new CommandError('Pattern not found: ' + str[1...-1])
+        throw new CommandError("Pattern not found: #{str[1...-1]}")
     else if str[0] is "?"
       addr = Find.findPreviousInBuffer(@editor.buffer, curPos, str[1...-1])
       unless addr?
-        throw new CommandError('Pattern not found: ' + str[1...-1])
+        throw new CommandError("Pattern not found: #{str[1...-1]}")
 
     return addr
 

--- a/lib/ex-mode.coffee
+++ b/lib/ex-mode.coffee
@@ -32,5 +32,5 @@ module.exports = ExMode =
     registerCommand: Ex.registerCommand.bind(Ex)
 
   consumeVim: (vim) ->
-    console.log vim
     @vim = vim
+    @globalExState.setVim(vim)

--- a/lib/ex-state.coffee
+++ b/lib/ex-state.coffee
@@ -1,6 +1,7 @@
 {Emitter, Disposable, CompositeDisposable} = require 'event-kit'
 
-{Command, CommandError} = require './command'
+Command = require './command'
+CommandError = require './command-error'
 
 class ExState
   constructor: (@editorElement, @globalExState) ->

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -41,7 +41,9 @@ class Ex
 
   q: => @quit()
 
-  tabedit: (filePaths...) ->
+  tabedit: (range, args) ->
+    args = args.trimLeft()
+    filePaths = args.split(' ')
     pane = atom.workspace.getActivePane()
     if filePaths? and filePaths.length > 0
       for file in filePaths
@@ -49,9 +51,9 @@ class Ex
     else
       atom.workspace.openURIInPane('', pane)
 
-  tabe: (filePaths...) => @tabedit(filePaths...)
+  tabe: (args...) => @tabedit(args...)
 
-  tabnew: (filePaths...) => @tabedit(filePaths...)
+  tabnew: (args...) => @tabedit(args...)
 
   tabclose: => @quit()
 
@@ -69,13 +71,14 @@ class Ex
 
   tabp: => @tabprevious()
 
-  edit: (filePath) => @tabedit(filePath) if filePath?
+  edit: (range, filePath) => @tabedit(range, filePath) if filePath?
 
-  e: (filePath) => @edit(filePath)
+  e: (args...) => @edit(args...)
 
   enew: => @edit()
 
-  write: (filePath) ->
+  write: (range, filePath) ->
+    filePath = filePath.trimLeft()
     deferred = Promise.defer()
 
     projectPath = atom.project.getPath()
@@ -111,18 +114,20 @@ class Ex
 
     deferred.promise
 
-  w: (filePath) =>
-    @write(filePath)
+  w: (args...) =>
+    @write(args...)
 
-  wq: (filePath) =>
-    @write(filePath).then => @quit()
+  wq: (args...) =>
+    @write(args...).then => @quit()
 
   x: => @wq()
 
   wa: ->
     atom.workspace.saveAll()
 
-  split: (filePaths...) ->
+  split: (range, args) ->
+    args = args.trimLeft()
+    filePaths = args.splitLeft()
     pane = atom.workspace.getActivePane()
     if filePaths? and filePaths.length > 0
       newPane = pane.splitUp()
@@ -132,9 +137,11 @@ class Ex
     else
       pane.splitUp(copyActiveItem: true)
 
-  sp: (filePaths...) => @split(filePaths...)
+  sp: (args...) => @split(args...)
 
-  vsplit: (filePaths...) ->
+  vsplit: (range, args) ->
+    args = args.trimLeft()
+    filePaths = args.split(' ')
     pane = atom.workspace.getActivePane()
     if filePaths? and filePaths.length > 0
       newPane = pane.splitLeft()
@@ -144,6 +151,6 @@ class Ex
     else
       pane.splitLeft(copyActiveItem: true)
 
-  vsp: (filePaths...) => @vsplit(filePaths...)
+  vsp: (args...) => @vsplit(args...)
 
 module.exports = Ex

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -198,11 +198,9 @@ class Ex
       else
         throw e
 
-    console.log pattern, [[range[0], 0]]
     buffer = atom.workspace.getActiveTextEditor().buffer
     # This adds an entry to the history for each replacement
     for line in [range[0]..range[1]]
-      console.log line
       buffer.scanInRange(pattern,
         [[line, 0], [line, buffer.lines[line].length]],
         ({match, matchText, range, stop, replace}) ->

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -9,15 +9,21 @@ trySave = (func) ->
   catch error
     if error.message.endsWith('is a directory')
       atom.notifications.addWarning("Unable to save file: #{error.message}")
-    else if error.code is 'EACCES' and error.path?
-      atom.notifications.addWarning("Unable to save file: Permission denied '#{error.path}'")
-    else if error.code in ['EPERM', 'EBUSY', 'UNKNOWN', 'EEXIST'] and error.path?
-      atom.notifications.addWarning("Unable to save file '#{error.path}'", detail: error.message)
-    else if error.code is 'EROFS' and error.path?
-      atom.notifications.addWarning("Unable to save file: Read-only file system '#{error.path}'")
-    else if errorMatch = /ENOTDIR, not a directory '([^']+)'/.exec(error.message)
+    else if error.path?
+      if error.code is 'EACCES'
+        atom.notifications
+          .addWarning("Unable to save file: Permission denied '#{error.path}'")
+      else if error.code in ['EPERM', 'EBUSY', 'UNKNOWN', 'EEXIST']
+        atom.notifications.addWarning("Unable to save file '#{error.path}'",
+          detail: error.message)
+      else if error.code is 'EROFS'
+        atom.notifications.addWarning(
+          "Unable to save file: Read-only file system '#{error.path}'")
+    else if (errorMatch =
+        /ENOTDIR, not a directory '([^']+)'/.exec(error.message))
       fileName = errorMatch[1]
-      atom.notifications.addWarning("Unable to save file: A directory in the path '#{fileName}' could not be written to")
+      atom.notifications.addWarning("Unable to save file: A directory in the "+
+        "path '#{fileName}' could not be written to")
     else
       throw error
 
@@ -110,7 +116,7 @@ class Ex
 
   wq: (filePath) =>
     @write(filePath).then => @quit()
-  
+
   x: => @wq()
 
   wa: ->

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -199,19 +199,14 @@ class Ex
         throw e
 
     buffer = atom.workspace.getActiveTextEditor().buffer
-    # This adds an entry to the history for each replacement
+    cp = buffer.history.createCheckpoint()
     for line in [range[0]..range[1]]
       buffer.scanInRange(pattern,
         [[line, 0], [line, buffer.lines[line].length]],
         ({match, matchText, range, stop, replace}) ->
           replace(replaceGroups(match[..], spl[1]))
       )
-    # This finds all matches in the buffer, sadly
-    # buffer.scanInRange(pattern,
-    #   [[range[0], 0], [range[1], buffer.lines[range[1]]].length],
-    #   ({match, matchText, range, stop, replace}) ->
-    #     console.log match, matchText
-    #   )
+    buffer.history.groupChangesSinceCheckpoint(cp)
 
   s: (args...) => @substitute(args...)
 

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -1,26 +1,27 @@
 module.exports = {
-  findLines: (lines, pattern) ->
-    # TODO: There's gotta be a better way to do this. Can we use vim-mode's
-    # search or find-and-replace maybe?
-    return (i for line, i in lines when line.match(pattern))
+  findInBuffer : (buffer, pattern) ->
+    found = []
+    buffer.scan(new RegExp(pattern, 'g'), (obj) -> found.push obj.range)
+    return found
 
-  findNext: (lines, pattern, curLine) ->
-    lines = @findLines(lines, pattern)
-    if lines.length == 0
-      return null
-    more = (i for i in lines when i > curLine)
+  findNextInBuffer : (buffer, curPos, pattern) ->
+    found = @findInBuffer(buffer, pattern)
+    more = (i for i in found when i.compare([curPos, curPos]) is 1)
     if more.length > 0
-      return more[0]
+      return more[0].start.row
+    else if found.length > 0
+      return found[0].start.row
     else
-      return lines[0]
-
-  findPrevious: (lines, pattern, curLine) ->
-    lines = @findLines(lines, pattern)
-    if lines.length == 0
       return null
-    less = (i for i in lines when i < curLine)
+
+  findPreviousInBuffer : (buffer, curPos, pattern) ->
+    found = @findInBuffer(buffer, pattern)
+    console.log found, curPos
+    less = (i for i in found when i.compare([curPos, curPos]) is -1)
     if less.length > 0
-      return less[0]
+      return less[less.length - 1].start.row
+    else if found.length > 0
+      return found[found.length - 1].start.row
     else
-      return lines[lines.length - 1]
+      return null
 }

--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -1,0 +1,26 @@
+module.exports = {
+  findLines: (lines, pattern) ->
+    # TODO: There's gotta be a better way to do this. Can we use vim-mode's
+    # search or find-and-replace maybe?
+    return (i for line, i in lines when line.match(pattern))
+
+  findNext: (lines, pattern, curLine) ->
+    lines = @findLines(lines, pattern)
+    if lines.length == 0
+      return null
+    more = (i for i in lines when i > curLine)
+    if more.length > 0
+      return more[0]
+    else
+      return lines[0]
+
+  findPrevious: (lines, pattern, curLine) ->
+    lines = @findLines(lines, pattern)
+    if lines.length == 0
+      return null
+    less = (i for i in lines when i < curLine)
+    if less.length > 0
+      return less[0]
+    else
+      return lines[lines.length - 1]
+}

--- a/lib/global-ex-state.coffee
+++ b/lib/global-ex-state.coffee
@@ -1,4 +1,5 @@
 class GlobalExState
   commandHistory: []
+  setVim: (@vim) ->
 
 module.exports = GlobalExState

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   "consumedServices": {
     "vim-mode": {
       "versions": {
-        "^0.33.0": "consumeVim"
+        "^0.1.0": "consumeVim"
       }
     }
   },


### PR DESCRIPTION
This comment doesn't really cover everything it should, but I'm a bit short on time and also tired, so test it out if you want to.

Fixes #5, #6 and #25.

This implements command parsing (mainly) following the [ex spec](http://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#tag_20_40_13_03), allowing more powerful commands like :s to be implemented.

Commands in the Ex class are called with the range as the first element, then all text following the command, so they require some rewriting (notably splitting the arguments manually).

There were some design choices to be made, so let's see how you like it.

    :'a+10

Moves the cursor to the 10th line after the vim-mode mark `a`.

     :'a,?\d?s/\s+/ /g

This would replace all whitespace in the lines between the vim-mode mark `a` and the first backwards matching digit with a single space.

Oh, and I also made the :e command behave like vim's :e, opening the file in the same tab, not a new one.