### PR TITLE
Fix `:x` throwing an error

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -145,7 +145,7 @@ class Ex
   wq: (args...) =>
     @write(args...).then => @quit()
 
-  x: => @wq()
+  x: (args...) => @wq(args...)
 
   wa: ->
     atom.workspace.saveAll()


### PR DESCRIPTION
`:x` threw an error because the arguments weren't properly passed on.