### PR TITLE
fix getFullPath(): support ~ as reference to home dir

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -1,4 +1,5 @@
 path = require 'path'
+fs = require 'fs-plus'
 CommandError = require './command-error'
 
 trySave = (func) ->
@@ -31,6 +32,7 @@ trySave = (func) ->
   deferred.promise
 
 getFullPath = (filePath) ->
+  filePath = fs.normalize(filePath)
   return filePath if path.isAbsolute(filePath)
   return path.join(atom.project.getPath(), filePath)
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -165,6 +165,28 @@ class Ex
     else
       pane.splitUp(copyActiveItem: true)
 
+  set: (args...) ->
+    editor = ->
+        atom.workspace.getActiveTextEditor()
+
+    arg   = args[1]
+    regex = /\s*(\w+)(?:\s*=\s*([\d\w]+)\s*|(!))/
+    matches = arg.match regex
+    return unless matches?
+
+    [whole, option, value, bang] = matches
+
+    switch option
+      when 'tw'
+        editor().setTabLength(parseInt(value))
+      when 'ft'
+        regex = new RegExp "(source|text)\.#{value}$"
+        lowerCaseName = value.toLowerCase()
+        for name, grammar of atom.grammars.grammarsByScopeName
+          grammarName = grammar.name.toLowerCase()
+          if name.match(regex) or lowerCaseName is grammarName
+            editor().setGrammar(grammar)
+
   sp: (args...) => @split(args...)
 
   substitute: (range, args) ->

--- a/package.json
+++ b/package.json
@@ -12,10 +12,11 @@
     "atom": ">=0.200.0 <2.0.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
+    "atom-space-pen-views": "^2.0.4",
     "event-kit": "^0.7.2",
+    "fs-plus": "^2.8.1",
     "space-pen": "^5.1.1",
-    "atom-space-pen-views": "^2.0.4"
+    "underscore-plus": "1.x"
   },
   "consumedServices": {
     "vim-mode": {


### PR DESCRIPTION
Currently, `:edit` doesnt consider `~/path/to/file` as a valid path.