### PR TITLE
Add '~/path' support to getFullPath; remove deprecation

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -39,7 +39,7 @@ saveAs = (filePath) ->
 getFullPath = (filePath) ->
   filePath = fs.normalize filePath
   return filePath if path.isAbsolute(filePath)
-  return path.join(atom.project.getPath(), filePath)
+  return path.join(atom.project.getPaths()[0], filePath)
 
 replaceGroups = (groups, replString) ->
   arr = replString.split('')

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -104,10 +104,10 @@ class Ex
     filePath = filePath.trim()
     if filePath.indexOf(' ') isnt -1
       throw new CommandError('Only one file name allowed')
-
-    filePath = getFullPath filePath
-    atom.workspace.open(filePath)
-
+    buffer = atom.workspace.getActiveTextEditor().buffer
+    filePath = buffer.getPath() if filePath is ''
+    buffer.setPath(getFullPath(filePath))
+    buffer.load()
 
   e: (args...) => @edit(args...)
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -1,6 +1,6 @@
 path = require 'path'
 CommandError = require './command-error'
-fs = require 'fs'
+fs = require 'fs-plus'
 
 trySave = (func) ->
   deferred = Promise.defer()
@@ -102,10 +102,10 @@ class Ex
     filePath = filePath.trim()
     if filePath.indexOf(' ') isnt -1
       throw new CommandError('Only one file name allowed')
-    buffer = atom.workspace.getActiveTextEditor().buffer
-    filePath = buffer.getPath() if filePath is ''
-    buffer.setPath(getFullPath(filePath))
-    buffer.load()
+
+    filePath = fs.normalize filePath
+    atom.workspace.open(filePath)
+
 
   e: (args...) => @edit(args...)
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -37,6 +37,7 @@ saveAs = (filePath) ->
   fs.writeFileSync(filePath, editor.getText())
 
 getFullPath = (filePath) ->
+  filePath = fs.normalize filePath
   return filePath if path.isAbsolute(filePath)
   return path.join(atom.project.getPath(), filePath)
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
+fs   = require 'fs-plus'
+
 CommandError = require './command-error'
-fs = require 'fs-plus'
 
 trySave = (func) ->
   deferred = Promise.defer()
@@ -103,7 +104,7 @@ class Ex
     if filePath.indexOf(' ') isnt -1
       throw new CommandError('Only one file name allowed')
 
-    filePath = fs.normalize filePath
+    filePath = getFullPath filePath
     atom.workspace.open(filePath)
 
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "underscore-plus": "1.x",
     "event-kit": "^0.7.2",
     "space-pen": "^5.1.1",
-    "atom-space-pen-views": "^2.0.4"
+    "atom-space-pen-views": "^2.0.4",
+    "fs-plus": "^2.2.8"
   },
   "consumedServices": {
     "vim-mode": {


### PR DESCRIPTION
* Replace `buffer.setPath()` call by `atom.workspace.open()`

**why?** Otherwise, `:edit` opens the file in the current TextEditor, which means that whatever was 
  in current editor is not there anymore.

* Add `fs-plus` dependency, call `fs.normalize` in `getFullPath()`

**why?** fs-plus's `normalize()` supports `~/paths`. 
Currently `:edit ~/file.txt` opens file `/path/to/project/~/file.txt` instead of `/home/user/file.txt`