### PR TITLE
Projects can have multiple paths

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -37,7 +37,7 @@ saveAs = (filePath) ->
 
 getFullPath = (filePath) ->
   return filePath if path.isAbsolute(filePath)
-  return path.join(atom.project.getPath(), filePath)
+  return path.join(atom.project.getPaths()[0], filePath)
 
 replaceGroups = (groups, replString) ->
   arr = replString.split('')


### PR DESCRIPTION
Projects can have multiple root paths for a while now. `Project.getPath()` doesn't show up in the docs since v0.135.0 and it doesn't work anymore now, so let's just use the first project root path when using relative paths.