### PR TITLE
Display ':' at start of the command input line

### DIFF
--- a/styles/ex-mode.less
+++ b/styles/ex-mode.less
@@ -6,3 +6,7 @@
 
 .ex-mode {
 }
+
+.command-mode-input atom-text-editor[mini]::before {
+  content: ":";
+}

--- a/styles/ex-mode.less
+++ b/styles/ex-mode.less
@@ -7,6 +7,6 @@
 .ex-mode {
 }
 
-.command-mode-input atom-text-editor[mini]::before {
+div[is=ex-command-mode-input] atom-text-editor[mini]::before {
   content: ":";
 }


### PR DESCRIPTION
Display ':' at start of the command input line

To match how Vim behaves when entering commands