### PR TITLE
Add support for :set [option]

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -1,6 +1,7 @@
 path = require 'path'
 CommandError = require './command-error'
 fs = require 'fs'
+VimOption = require './vim-option'
 
 trySave = (func) ->
   deferred = Promise.defer()
@@ -231,5 +232,28 @@ class Ex
   delete: (range) ->
     range = [[range[0], 0], [range[1] + 1, 0]]
     atom.workspace.getActiveTextEditor().buffer.setTextInRange(range, '')
+
+  set: (range, args) ->
+    args = args.trim()
+    if args == ""
+      throw new CommandError("No option specified")
+    options = args.split(' ')
+    for option in options
+      do ->
+        if option.includes("=")
+          nameValPair = option.split("=")
+          if (nameValPair.length != 2)
+            throw new CommandError("Wrong option format. [name]=[value] format is expected")
+          optionName = nameValPair[0]
+          optionValue = nameValPair[1]
+          optionProcessor = VimOption.singleton()[optionName]
+          if not optionProcessor?
+            throw new CommandError("No such option: #{optionName}")
+          optionProcessor(optionValue)
+        else
+          optionProcessor = VimOption.singleton()[option]
+          if not optionProcessor?
+            throw new CommandError("No such option: #{option}")
+          optionProcessor()
 
 module.exports = Ex

--- a/lib/vim-option.coffee
+++ b/lib/vim-option.coffee
@@ -1,0 +1,23 @@
+class VimOption
+  @singleton: =>
+    @option ||= new VimOption
+
+  list: =>
+    atom.config.set("editor.showInvisibles", true)
+
+  nolist: =>
+    atom.config.set("editor.showInvisibles", false)
+
+  number: =>
+    atom.config.set("editor.showLineNumbers", true)
+
+  nu: =>
+    @number()
+
+  nonumber: =>
+    atom.config.set("editor.showLineNumbers", false)
+
+  nonu: =>
+    @nonumber()
+
+module.exports = VimOption


### PR DESCRIPTION
This PR closes #68 and implements part of #8.

Implemented options are number(nu)/nonumber(nonu) and list/nolist.

I'm quite new to js/coffee-script and at the moment I'm unsure if I did it right with creating option class, though I mostly followed example of Ex.

Also the naming of the option class itself, `VimOption`, could be a subject of discussion.