### PR TITLE
Make cmd-line in ex-mode look like in vim-mode

### DIFF
--- a/styles/ex-mode.less
+++ b/styles/ex-mode.less
@@ -10,3 +10,15 @@
 div[is=ex-command-mode-input] atom-text-editor[mini]::before {
   content: ":";
 }
+
+.command-mode-input atom-text-editor[mini] {
+  background-color: inherit;
+  border: none;
+  width: 100%;
+  font-weight: normal;
+  color: @text-color;
+  line-height: 1.28;
+  cursor: default;
+  white-space: nowrap;
+  padding-left: 10px;
+}


### PR DESCRIPTION
Changed the style of .command-mode-input so that it looks like
.normal-mode-input from vim-mode.
This makes ex-mode more consistent with vim-mode