### PR TITLE
Don't allow :s delimiters not allowed by vim

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -199,9 +199,9 @@ class Ex
   substitute: (range, args) ->
     args = args.trimLeft()
     delim = args[0]
-    if /[a-z]/i.test(delim)
+    if /[a-z1-9\\"|]/i.test(delim)
       throw new CommandError(
-        "Regular expressions can't be delimited by letters")
+        "Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
     delimRE = new RegExp("[^\\\\]#{delim}")
     spl = []
     args_ = args[1..]

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -453,7 +453,14 @@ describe "the commands", ->
       keydown(':')
       submitNormalModeInputText(':substitute nanxngi')
       expect(atom.notifications.notifications[0].message).toEqual(
-        "Command error: Regular expressions can't be delimited by letters")
+        "Command error: Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
+      expect(editor.getText()).toEqual('abcaABC\ndefdDEF\nabcaABC')
+
+    it "can't be delimited by numbers", ->
+      keydown(':')
+      submitNormalModeInputText(':substitute 1a1x1gi')
+      expect(atom.notifications.notifications[0].message).toEqual(
+        "Command error: Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
       expect(editor.getText()).toEqual('abcaABC\ndefdDEF\nabcaABC')
 
     describe "capturing groups", ->

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -449,19 +449,19 @@ describe "the commands", ->
       submitNormalModeInputText(':%substitute/abc/ghi/ig')
       expect(editor.getText()).toEqual('ghiaghi\ndefdDEF\nghiaghi')
 
-    it "can't be delimited by letters", ->
-      keydown(':')
-      submitNormalModeInputText(':substitute nanxngi')
-      expect(atom.notifications.notifications[0].message).toEqual(
-        "Command error: Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
-      expect(editor.getText()).toEqual('abcaABC\ndefdDEF\nabcaABC')
+    describe "illegal delimiters", ->
+      test = (delim) ->
+        keydown(':')
+        submitNormalModeInputText(":substitute #{delim}a#{delim}x#{delim}gi")
+        expect(atom.notifications.notifications[0].message).toEqual(
+          "Command error: Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
+        expect(editor.getText()).toEqual('abcaABC\ndefdDEF\nabcaABC')
 
-    it "can't be delimited by numbers", ->
-      keydown(':')
-      submitNormalModeInputText(':substitute 1a1x1gi')
-      expect(atom.notifications.notifications[0].message).toEqual(
-        "Command error: Regular expressions can't be delimited by alphanumeric characters, '\\', '\"' or '|'")
-      expect(editor.getText()).toEqual('abcaABC\ndefdDEF\nabcaABC')
+      it "can't be delimited by letters", -> test 'n'
+      it "can't be delimited by numbers", -> test '3'
+      it "can't be delimited by '\\'",    -> test '\\'
+      it "can't be delimited by '\"'",    -> test '"'
+      it "can't be delimited by '|'",     -> test '|'
 
     describe "capturing groups", ->
       beforeEach ->


### PR DESCRIPTION
> Instead of the '/' which surrounds the pattern and replacement string,
you can use any other single-byte character, but not an alphanumeric
character, '\', '"'' or '|'.

([Vim docs](http://vimdoc.sourceforge.net/htmldoc/change.html#:substitute))

I'm open to suggestions on how to improve the code!