### PR TITLE
Add option to register alias keys in atom init config

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -71,6 +71,9 @@ class Ex
   @registerCommand: (name, func) =>
     @singleton()[name] = func
 
+  @registerAlias: (alias, name) =>
+    @singleton()[alias] = @singleton()[name]
+
   quit: ->
     atom.workspace.getActivePane().destroyActiveItem()
 


### PR DESCRIPTION
Add ability to register alias keys without having to copy the original functions.

Use case example: register `W` as typo fallback for `w`