### PR TITLE
Added :wall

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -178,7 +178,9 @@ class Ex
 
   xit: (args...) => @wq(args...)
 
-  wa: ->
+  wa: => @wall()
+  
+  wall: ->
     atom.workspace.saveAll()
 
   split: (range, args) ->


### PR DESCRIPTION
While `:wa` previously existed, the full comment `:wall` did not. Fixes #114 .