### PR TITLE
Rework command calling, improve :substitute

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -150,7 +150,7 @@ class Command
 
     # If the command matches an existing one exactly, execute that one
     if (func = Ex.singleton()[command])?
-      func(range, args)
+      func({ range, args, @vimState, @exState, @editor })
     else
       # Step 8: Match command against existing commands
       matching = (name for name, val of Ex.singleton() when \
@@ -162,7 +162,7 @@ class Command
 
       func = Ex.singleton()[command]
       if func?
-        func(range, args)
+        func({ range, args, @vimState, @exState, @editor })
       else
         throw new CommandError("Not an editor command: #{input.characters}")
 


### PR DESCRIPTION
This reworks the way commands are called. Commands are now called with an object

```coffeescript
{ range, args, vimState, exState, editor }
```

instead of a long list of arguments so they can access more information without bloating the function definition.

This PR also improves `:substitute` so that it replaces escape sequences and allows replacing with an empty string. It also integrates with the vim search history so that you can replace the last search (`:s//abc`) and so that the patterns from `:substitute` also get pushed to the search history.