### PR TITLE
Add aliases for Wq and WQ for fat finger mistakes.

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -230,6 +230,12 @@ class Ex
   wq: (args) =>
     @write(args).then => @quit()
 
+  Wq: (args) =>
+    @write(args).then => @quit()
+
+  WQ: (args) =>
+    @write(args).then => @quit()
+
   wa: =>
     @wall()
 


### PR DESCRIPTION
I always fat finger these two and then I get an error telling me that I am
doing a command that doesn't exist. I added these two so that when I fat finger
it and capitalize something the program still exits like I want it to.