### PR TITLE
Feature/yanking

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -349,6 +349,11 @@ class Ex
     range = [[range[0], 0], [range[1] + 1, 0]]
     atom.workspace.getActiveTextEditor().buffer.setTextInRange(range, '')
 
+  yank: ({ range }) ->
+    range = [[range[0], 0], [range[1] + 1, 0]]
+    txt = atom.workspace.getActiveTextEditor().getTextInBufferRange(range)
+    atom.clipboard.write(txt);
+
   set: ({ range, args }) ->
     args = args.trim()
     if args == ""

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -585,6 +585,23 @@ describe "the commands", ->
       submitNormalModeInputText(':%substitute/abc/ghi/ig')
       expect(editor.getText()).toEqual('ghiaghi\ndefdDEF\nghiaghi')
 
+    describe ":yank", ->
+      beforeEach ->
+        editor.setText('abc\ndef\nghi\njkl')
+        editor.setCursorBufferPosition([2, 0])
+
+      it "yanks the current line", ->
+        keydown(':')
+        submitNormalModeInputText('yank')
+        expect(atom.clipboard.read()).toEqual('ghi\n')
+
+      it "yanks the lines in the given range", ->
+        processedOpStack = false
+        exState.onDidProcessOpStack -> processedOpStack = true
+        keydown(':')
+        submitNormalModeInputText('1,2yank')
+        expect(atom.clipboard.read()).toEqual('abc\ndef\n')
+
     describe "illegal delimiters", ->
       test = (delim) ->
         keydown(':')

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -596,8 +596,6 @@ describe "the commands", ->
         expect(atom.clipboard.read()).toEqual('ghi\n')
 
       it "yanks the lines in the given range", ->
-        processedOpStack = false
-        exState.onDidProcessOpStack -> processedOpStack = true
         keydown(':')
         submitNormalModeInputText('1,2yank')
         expect(atom.clipboard.read()).toEqual('abc\ndef\n')


### PR DESCRIPTION
Support yanking commands (e.g., `:1,4y`).  Yanked text copied to atom clipboard.

Yanking code and spec adapted from delete code and spec.

Addresses part of #99 