### PR TITLE
Copy to text to clipboard on delete

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -347,7 +347,12 @@ class Ex
 
   delete: ({ range }) ->
     range = [[range[0], 0], [range[1] + 1, 0]]
-    atom.workspace.getActiveTextEditor().buffer.setTextInRange(range, '')
+    editor = atom.workspace.getActiveTextEditor()
+
+    text = editor.getTextInBufferRange(range)
+    atom.clipboard.write(text)
+
+    editor.buffer.setTextInRange(range, '')
 
   set: ({ range, args }) ->
     args = args.trim()

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -530,6 +530,11 @@ describe "the commands", ->
       submitNormalModeInputText('delete')
       expect(editor.getText()).toEqual('abc\ndef\njkl')
 
+    it "copies the deleted text", ->
+      keydown(':')
+      submitNormalModeInputText('delete')
+      expect(atom.clipboard.read()).toEqual('ghi\n')
+
     it "deletes the lines in the given range", ->
       processedOpStack = false
       exState.onDidProcessOpStack -> processedOpStack = true


### PR DESCRIPTION
Currently, when running a delete command (e.g., `:1,4d`), the text is deleted but not copied to the clipboard.

This PR causes deleted text to be copied to the clipboard.