### PR TITLE
Fix tabnew with arguments

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -127,11 +127,11 @@ class Ex
 
   tabe: (args) => @tabedit(args)
 
-  tabnew: ({ range, args }) =>
-    if args.trim() is ''
+  tabnew: (args) =>
+    if args.args.trim() is ''
       atom.workspace.open()
     else
-      @tabedit(range, args)
+      @tabedit(args)
 
   tabclose: (args) => @quit(args)
 

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -496,6 +496,14 @@ describe "the commands", ->
       submitNormalModeInputText('tabnew')
       expect(atom.workspace.open).toHaveBeenCalled()
 
+    it "opens a new tab for editing when provided an argument", ->
+      spyOn(Ex, 'tabnew').andCallThrough()
+      spyOn(Ex, 'tabedit')
+      keydown(':')
+      submitNormalModeInputText('tabnew tabnew-test')
+      expect(Ex.tabedit)
+        .toHaveBeenCalledWith(Ex.tabnew.calls[0].args...)
+
   describe ":split", ->
     it "splits the current file upwards/downward", ->
       pane = atom.workspace.getActivePane()


### PR DESCRIPTION
Fixes #146 

Changes Proposed in this Pull Request:
- Fixes a bug in the way tabnew forwarded arguments to tabedit.

I have written tests for:
Calling tabnew with arguments

- [x] Bugs fixed
- [x] Test cases added

@jazzpi @LongLiveCHIEF
