### PR TITLE
polyfill Promise with bluebird

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -3,6 +3,7 @@ CommandError = require './command-error'
 fs = require 'fs-plus'
 VimOption = require './vim-option'
 _ = require 'underscore-plus'
+Promise = require 'bluebird'
 
 trySave = (func) ->
   deferred = Promise.defer()

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ex-mode",
   "main": "./lib/ex-mode",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Ex for Atom's vim-mode",
   "activationCommands": {
     "atom-workspace": "ex-mode:open"
@@ -12,11 +12,12 @@
     "atom": ">=0.200.0 <2.0.0"
   },
   "dependencies": {
-    "underscore-plus": "1.x",
-    "event-kit": "^0.7.2",
-    "space-pen": "^5.1.1",
     "atom-space-pen-views": "^2.0.4",
-    "fs-plus": "^2.2.8"
+    "bluebird": "^3.4.1",
+    "event-kit": "^0.7.2",
+    "fs-plus": "^2.2.8",
+    "space-pen": "^5.1.1",
+    "underscore-plus": "1.x"
   },
   "consumedServices": {
     "vim-mode": {


### PR DESCRIPTION
Fixes #147 
- occurs on atom 1.9 stable 
- fix manually tested on linux (ubuntu 16.04) and mac OSx (10.11.6)
- `$ apm test` fixes 21 of 23 broken tests

```
TypeError: Promise.defer is not a function
    at Ex.write (/Users/awatters/.atom/packages/ex-mode/lib/ex.coffee:197:24)
    at Ex.w (/Users/awatters/.atom/packages/ex-mode/lib/ex.coffee:228:6)
    at /Users/awatters/.atom/packages/ex-mode/lib/ex.coffee:1:1
    at Command.execute (/Users/awatters/.atom/packages/ex-mode/lib/command.coffee:153:7)
    at ExState.processOpStack (/Users/awatters/.atom/packages/ex-mode/lib/ex-state.coffee:53:17)
    at ExState.pushOperations (/Users/awatters/.atom/packages/ex-mode/lib/ex-state.coffee:43:6)
    at ExViewModel.ViewModel.confirm (/Users/awatters/.atom/packages/ex-mode/lib/view-model.coffee:13:14)
    at ExViewModel.module.exports.ExViewModel.confirm (/Users/awatters/.atom/packages/ex-mode/lib/ex-view-model.coffee:35:5)
    at ExViewModel.confirm (/Users/awatters/.atom/packages/ex-mode/lib/ex-view-model.coffee:1:1)
    at ex-command-mode-input.ExCommandModeInputElement.confirm (/Users/awatters/.atom/packages/ex-mode/lib/ex-normal-mode-input-element.coffee:51:16)
    at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:260:29)
    at /Applications/Atom.app/Contents/Resources/app.asar/src/command-registry.js:3:61
    at KeymapManager.module.exports.KeymapManager.dispatchCommandEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:580:16)
    at KeymapManager.module.exports.KeymapManager.handleKeyboardEvent (/Applications/Atom.app/Contents/Resources/app.asar/node_modules/atom-keymap/lib/keymap-manager.js:388:22)
    at WindowEventHandler.module.exports.WindowEventHandler.handleDocumentKeyEvent (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:98:36)
    at HTMLDocument.<anonymous> (/Applications/Atom.app/Contents/Resources/app.asar/src/window-event-handler.js:3:61)
```

Changes Proposed in this Pull Request:
- adds bluebird promises
- bumps version

I have written tests for:

- [ ] Neither (I'm just fixing stuff)

Testing:

without bluebird
```
$ apm test
Finished in 5.473 seconds
93 tests, 121 assertions, 23 failures, 0 skipped
```

with bluebird
```
$ apm test
Finished in 5.942 seconds
93 tests, 147 assertions, 2 failures, 0 skipped

Fails
===
the commands
  :wq
    it writes the file, then quits
      timeout: timed out after 100 msec waiting for the :quit command to be called
    it passes the file name
      timeout: timed out after 100 msec waiting for the :quit command to be called
```


@jazzpi @LongLiveCHIEF



