### PR TITLE
Update editor when saving a new file with `:w` or `:saveas`

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -222,7 +222,7 @@ class Ex
     if not saved and fullPath?
       if not force and fs.existsSync(fullPath)
         throw new CommandError("File exists (add ! to override)")
-      if saveas
+      if saveas or editor.getFileName() == null
         editor = atom.workspace.getActiveTextEditor()
         trySave(-> editor.saveAs(fullPath, editor)).then(deferred.resolve)
       else

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -79,6 +79,7 @@ describe "the commands", ->
         submitNormalModeInputText('write')
         expect(fs.existsSync(filePath)).toBe(true)
         expect(fs.readFileSync(filePath, 'utf-8')).toEqual('abc\ndef')
+        expect(editor.isModified()).toBe(false)
 
       it "saves when a path is specified in the save dialog", ->
         spyOn(atom, 'showSaveDialogSync').andReturn(undefined)


### PR DESCRIPTION
Fixes #156.

Changes Proposed in this Pull Request:
- Update the editor when a new file is first saved, similar to `:saveas`

I have written tests for:

- [ ] New features introduced
- [x] Bugs fixed
- [ ] Neither (I'm just enhancing tests!)

@jazzpi @LongLiveCHIEF

Fixes #156