### PR TITLE
Add splitbelow and splitright options to `:set`

### DIFF
--- a/lib/vim-option.coffee
+++ b/lib/vim-option.coffee
@@ -20,4 +20,28 @@ class VimOption
   nonu: =>
     @nonumber()
 
+  splitright: =>
+    atom.config.set("ex-mode.splitright", true)
+
+  spr: =>
+    @splitright()
+
+  nosplitright: =>
+    atom.config.set("ex-mode.splitright", false)
+
+  nospr: =>
+    @nosplitright()
+
+  splitbelow: =>
+    atom.config.set("ex-mode.splitbelow", true)
+
+  sb: =>
+    @splitbelow()
+
+  nosplitbelow: =>
+    atom.config.set("ex-mode.splitbelow", false)
+
+  nosb: =>
+    @nosplitbelow()
+
 module.exports = VimOption

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -802,6 +802,34 @@ describe "the commands", ->
         submitNormalModeInputText(':set nonumber')
         expect(atom.config.get('editor.showLineNumbers')).toBe(false)
 
+      it "sets (no)sp(lit)r(ight)", ->
+        keydown(':')
+        submitNormalModeInputText(':set spr')
+        expect(atom.config.get('ex-mode.splitright')).toBe(true)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set nospr')
+        expect(atom.config.get('ex-mode.splitright')).toBe(false)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set splitright')
+        expect(atom.config.get('ex-mode.splitright')).toBe(true)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set nosplitright')
+        expect(atom.config.get('ex-mode.splitright')).toBe(false)
+
+      it "sets (no)s(plit)b(elow)", ->
+        keydown(':')
+        submitNormalModeInputText(':set sb')
+        expect(atom.config.get('ex-mode.splitbelow')).toBe(true)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set nosb')
+        expect(atom.config.get('ex-mode.splitbelow')).toBe(false)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set splitbelow')
+        expect(atom.config.get('ex-mode.splitbelow')).toBe(true)
+        atom.commands.dispatch(editorElement, 'ex-mode:open')
+        submitNormalModeInputText(':set nosplitbelow')
+        expect(atom.config.get('ex-mode.splitbelow')).toBe(false)
+
   describe "aliases", ->
     it "calls the aliased function without arguments", ->
       ExClass.registerAlias('W', 'w')


### PR DESCRIPTION
Changes Proposed in this Pull Request:
- Make the existing splitbelow and splitright package options available via `:set`

I have written tests for:

- [x] New features introduced
- [ ] Bugs fixed
- [ ] Neither (I'm just enhancing tests!)

@jazzpi @LongLiveCHIEF