### PR TITLE
Fix mark addresses and add specs for addresses

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -24,7 +24,7 @@ class Command
       mark = @vimState.marks[str[1]]
       unless mark?
         throw new CommandError("Mark #{str} not set.")
-      addr = mark.bufferMarker.range.end.row
+      addr = mark.getEndBufferPosition().row
     else if str[0] is "/"
       addr = Find.findNextInBuffer(@editor.buffer, curPos, str[1...-1])
       unless addr?

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -107,7 +107,7 @@ describe "the commands", ->
     it "moves to a mark's line", ->
       keydown('l')
       keydown('m')
-      commandModeInputKeydown 'a'
+      normalModeInputKeydown 'a'
       keydown('j')
       openEx()
       submitNormalModeInputText "'a"
@@ -637,7 +637,6 @@ describe "the commands", ->
       waitsFor -> processedOpStack
       editor.setText('abc\ndef\nghi\njkl')
       editor.setCursorBufferPosition([1, 1])
-      # For some reason, keydown(':') doesn't work here :/
       atom.commands.dispatch(editorElement, 'ex-mode:open')
       submitNormalModeInputText(',/k/delete')
       expect(editor.getText()).toEqual('abc\n')

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -65,6 +65,68 @@ describe "the commands", ->
   openEx = ->
     atom.commands.dispatch(editorElement, "ex-mode:open")
 
+  describe "as a motion", ->
+    beforeEach ->
+      editor.setCursorBufferPosition([0, 0])
+
+    it "moves the cursor to a specific line", ->
+      openEx()
+      submitNormalModeInputText '2'
+
+      expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+    it "moves to the second address", ->
+      openEx()
+      submitNormalModeInputText '1,3'
+
+      expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+
+    it "works with offsets", ->
+      openEx()
+      submitNormalModeInputText '2+1'
+      expect(editor.getCursorBufferPosition()).toEqual [2, 0]
+
+      openEx()
+      submitNormalModeInputText '-2'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+    it "doesn't move when the address is the current line", ->
+      openEx()
+      submitNormalModeInputText '.'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      openEx()
+      submitNormalModeInputText ','
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+    it "moves to the last line", ->
+      openEx()
+      submitNormalModeInputText '$'
+      expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+
+    it "moves to a mark's line", ->
+      keydown('l')
+      keydown('m')
+      commandModeInputKeydown 'a'
+      keydown('j')
+      openEx()
+      submitNormalModeInputText "'a"
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+    it "moves to a specified search", ->
+      openEx()
+      submitNormalModeInputText '/def'
+      expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
+      openEx()
+      submitNormalModeInputText '?abc'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      editor.setCursorBufferPosition([3, 0])
+      openEx()
+      submitNormalModeInputText '/ef'
+      expect(editor.getCursorBufferPosition()).toEqual [1, 0]
+
   describe ":write", ->
     describe "when editing a new file", ->
       beforeEach ->


### PR DESCRIPTION
Fixes #70.

Changes Proposed in this Pull Request:

- Fix using marks as addresses - no idea where that code came from 😇
- Add specs for addresses by checking how ex behaves when used as a motion (e.g. `:3` or `:'a`)

I have written tests for:

[](Remove the `[]()` to uncomment the appropriate lines)

[](- New features introduced)
- Bugs fixed
- Neither (I'm just enhancing tests!)