### PR TITLE
Fix search not working without a closing delimiter

### DIFF
--- a/lib/find.coffee
+++ b/lib/find.coffee
@@ -1,3 +1,40 @@
+_ = require 'underscore-plus'
+
+getSearchTerm = (term, modifiers = {'g': true}) ->
+
+  escaped = false
+  hasc = false
+  hasC = false
+  term_ = term
+  term = ''
+  for char in term_
+    if char is '\\' and not escaped
+      escaped = true
+      term += char
+    else
+      if char is 'c' and escaped
+        hasc = true
+        term = term[...-1]
+      else if char is 'C' and escaped
+        hasC = true
+        term = term[...-1]
+      else if char isnt '\\'
+        term += char
+      escaped = false
+
+  if hasC
+    modifiers['i'] = false
+  if (not hasC and not term.match('[A-Z]') and \
+      atom.config.get("vim-mode:useSmartcaseForSearch")) or hasc
+    modifiers['i'] = true
+
+  modFlags = Object.keys(modifiers).filter((key) -> modifiers[key]).join('')
+
+  try
+    new RegExp(term, modFlags)
+  catch
+    new RegExp(_.escapeRegExp(term), modFlags)
+
 module.exports = {
   findInBuffer : (buffer, pattern) ->
     found = []
@@ -23,4 +60,26 @@ module.exports = {
       return found[found.length - 1].start.row
     else
       return null
+
+  # Returns an array of ranges of all occurences of `term` in `editor`.
+  #  The array is sorted so that the first occurences after the cursor come
+  #  first (and the search wraps around). If `reverse` is true, the array is
+  #  reversed so that the first occurence before the cursor comes first.
+  scanEditor: (term, editor, position, reverse = false) ->
+    [rangesBefore, rangesAfter] = [[], []]
+    editor.scan getSearchTerm(term), ({range}) ->
+      if reverse
+        isBefore = range.start.compare(position) < 0
+      else
+        isBefore = range.start.compare(position) <= 0
+
+      if isBefore
+        rangesBefore.push(range)
+      else
+        rangesAfter.push(range)
+
+    if reverse
+      rangesAfter.concat(rangesBefore).reverse()
+    else
+      rangesAfter.concat(rangesBefore)
 }

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -118,9 +118,10 @@ describe "the commands", ->
       submitNormalModeInputText '/def'
       expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
+      editor.setCursorBufferPosition([2, 0])
       openEx()
-      submitNormalModeInputText '?abc'
-      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+      submitNormalModeInputText '?def'
+      expect(editor.getCursorBufferPosition()).toEqual [1, 0]
 
       editor.setCursorBufferPosition([3, 0])
       openEx()


### PR DESCRIPTION
Changes Proposed in this Pull Request:

- Fix search not working without a closing delimiter

I have written tests for:

[](Remove the `[]()` to uncomment the appropriate lines)

[](- New features introduced)
- Bugs fixed
[](- Neither (I'm just enhancing tests!))

