### PR TITLE
Autocomplete non existant directory fix

### DIFF
--- a/lib/autocomplete.coffee
+++ b/lib/autocomplete.coffee
@@ -40,6 +40,7 @@ class AutoComplete
     if @completions.length == 0
       @completions = completeFunc()
 
+    complete = ''
     if @completions.length
       complete = @completions[@autoCompleteIndex % @completions.length]
       @autoCompleteIndex++
@@ -48,7 +49,7 @@ class AutoComplete
       if complete.endsWith('/') && @completions.length == 1
         @resetCompletion()
 
-      return complete
+    return complete
 
   getCommandCompletion: (command) ->
     return @filterByPrefix(@commands, command)
@@ -63,12 +64,17 @@ class AutoComplete
         basePath = path.dirname(filePath)
         baseName = path.basename(filePath)
 
-      files = fs.readdirSync(basePath)
-
-      return @filterByPrefix(files, baseName).map((f) =>
-        filePath = path.join(basePath, f)
-        if fs.lstatSync(filePath).isDirectory()
-          return command + ' ' + filePath  + path.sep
-        else
-          return command + ' ' + filePath
-      )
+      try
+        basePathStat = fs.statSync(basePath)
+        if basePathStat.isDirectory()
+          files = fs.readdirSync(basePath)
+          return @filterByPrefix(files, baseName).map((f) =>
+            filePath = path.join(basePath, f)
+            if fs.lstatSync(filePath).isDirectory()
+              return command + ' ' + filePath  + path.sep
+            else
+              return command + ' ' + filePath
+          )
+        return []
+      catch err
+        return []

--- a/spec/autocomplete-spec.coffee
+++ b/spec/autocomplete-spec.coffee
@@ -10,6 +10,7 @@ describe "autocomplete functionality", ->
   beforeEach ->
     @autoComplete = new AutoComplete(['taba', 'tabb', 'tabc'])
     @testDir = path.join(os.tmpdir(), "atom-ex-mode-spec-#{uuid.v4()}")
+    @nonExistentTestDir = path.join(os.tmpdir(), "atom-ex-mode-spec-#{uuid.v4()}")
     @testFile1 = path.join(@testDir, "atom-ex-testfile-a.txt")
     @testFile2 = path.join(@testDir, "atom-ex-testfile-b.txt")
 
@@ -80,3 +81,20 @@ describe "autocomplete functionality", ->
 
     it "lists files once", ->
       expect(@autoComplete.getFilePathCompletion.callCount).toBe(1)
+
+  describe "autocomplete non existent directory", ->
+    beforeEach ->
+      @completed = @autoComplete.getAutocomplete('tabe ' + @nonExistentTestDir)
+
+    it "returns no completions", ->
+      expected = '';
+      expect(@completed).toEqual(expected)
+
+  describe "autocomplete existing file as directory", ->
+    beforeEach ->
+      filePath = @testFile1 + path.sep
+      @completed = @autoComplete.getAutocomplete('tabe ' + filePath)
+
+    it "returns no completions", ->
+      expected = '';
+      expect(@completed).toEqual(expected)


### PR DESCRIPTION
Changes Proposed in this Pull Request:

- Fix autocompleting a non existent directory (e.g. `tabe /tmp/nothere/`). This was causing an uncaught `ENOENT` error.

I have written tests for:

[](Remove the `[]()` to uncomment the appropriate lines)

[](- New features introduced)
- Bugs fixed
[](- Neither (I'm just enhancing tests!))
