### PR TITLE
Limit addresses to the last line

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -123,8 +123,9 @@ class Command
           address1 += @parseOffset(off1)
 
         address1 = 0 if address1 is -1
+        address1 = lastLine if address1 > lastLine
 
-        if address1 < 0 or address1 > lastLine
+        if address1 < 0
           throw new CommandError('Invalid range')
 
         if addr2?
@@ -132,7 +133,10 @@ class Command
         if off2?
           address2 += @parseOffset(off2)
 
-        if address2 < 0 or address2 > lastLine
+        address2 = 0 if address2 is -1
+        address2 = lastLine if address2 > lastLine
+
+        if address2 < 0
           throw new CommandError('Invalid range')
 
         if address2 < address1

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -90,6 +90,33 @@ describe "the commands", ->
       submitNormalModeInputText '-2'
       expect(editor.getCursorBufferPosition()).toEqual [0, 0]
 
+    it "limits to the last line", ->
+      openEx()
+      submitNormalModeInputText '10'
+      expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+      editor.setCursorBufferPosition([0, 0])
+
+      openEx()
+      submitNormalModeInputText '3,10'
+      expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+      editor.setCursorBufferPosition([0, 0])
+
+      openEx()
+      submitNormalModeInputText '$+1000'
+      expect(editor.getCursorBufferPosition()).toEqual [3, 0]
+      editor.setCursorBufferPosition([0, 0])
+
+    it "goes to the first line with address 0", ->
+      editor.setCursorBufferPosition([2, 0])
+      openEx()
+      submitNormalModeInputText '0'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
+      editor.setCursorBufferPosition([2, 0])
+      openEx()
+      submitNormalModeInputText '0,0'
+      expect(editor.getCursorBufferPosition()).toEqual [0, 0]
+
     it "doesn't move when the address is the current line", ->
       openEx()
       submitNormalModeInputText '.'


### PR DESCRIPTION
Fixes #169.

Sets both the first and second address to the last line if they are over that line.

Also sets the second address to the first line if it is 0.

I have written tests for:

- Bugs fixed

