### PR TITLE
ex-mode supports vim-mode-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ ex-mode for Atom's vim-mode
 
 ## Use
 
-Install both [vim-mode](https://github.com/atom/vim-mode) and ex-mode. Type `:` in command mode. Enter `w` or `write`.
+Install both [vim-mode-plus](https://github.com/t9md/atom-vim-mode-plus) (or
+the deprecated `vim-mode`) and ex-mode. Type `:` in command mode. Enter `w` or
+`write`.
 
 ## Extend
 

--- a/keymaps/ex-mode.cson
+++ b/keymaps/ex-mode.cson
@@ -7,5 +7,7 @@
 
 # For more detailed documentation see
 # https://atom.io/docs/latest/advanced/keymaps
+'atom-text-editor.vim-mode-plus:not(.insert-mode)':
+  ':': 'ex-mode:open'
 'atom-text-editor.vim-mode:not(.insert-mode)':
   ':': 'ex-mode:open'


### PR DESCRIPTION
Changes Proposed in this Pull Request:

- Update the `README` file to mention `vim-mode-plus` as `vim-mode` has been deprecated.
- Update the keymap to match

Tests: I'm not sure a test is necessary for this, would appreciate guidance.