### PR TITLE
Fix `:x` closing Atom instead of the current pane

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -276,6 +276,7 @@ class Ex
 
   xit: (args) => @wq(args)
 
+  x: (args) => @xit(args)
 
   split: ({ range, args }) ->
     args = args.trim()

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -485,6 +485,13 @@ describe "the commands", ->
       submitNormalModeInputText('xit')
       expect(Ex.wq).toHaveBeenCalled()
 
+  describe ":x", ->
+    it "acts as an alias to :xit", ->
+      spyOn(Ex, 'xit')
+      openEx()
+      submitNormalModeInputText('x')
+      expect(Ex.xit).toHaveBeenCalled()
+
   describe ":wqall", ->
     it "calls :wall, then :quitall", ->
       spyOn(Ex, 'wall')


### PR DESCRIPTION
`x` was being matched with `xall` instead of `xit`, so add an alias.

Fixes #167 .

Changes Proposed in this Pull Request:

- Make `x` an alias to `xit`

I have written tests for:

- Bugs fixed
