### PR TITLE
[needs tests] Support vim-mode-plus substitute command

### DIFF
--- a/lib/ex-mode.coffee
+++ b/lib/ex-mode.coffee
@@ -36,6 +36,9 @@ module.exports = ExMode =
     @vim = vim
     @globalExState.setVim(vim)
 
+  consumeVimModePlus: (vim) ->
+    this.consumeVim(vim)
+
   config:
     splitbelow:
       title: 'Split below'

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -335,12 +335,23 @@ class Ex
 
     [pattern, substition, flags] = parsed
     if pattern is ''
-      pattern = vimState.getSearchHistoryItem()
+      if vimState.getSearchHistoryItem?
+        # vim-mode
+        pattern = vimState.getSearchHistoryItem()
+      else if vimState.searchHistory?
+        #vim-mode-plus
+        pattern = vimState.searchHistory.get('prev')
+
       if not pattern?
         atom.beep()
         throw new CommandError('No previous regular expression')
     else
-      vimState.pushSearchHistory(pattern)
+      if vimState.pushSearchHistory?
+        # vim-mode
+        vimState.pushSearchHistory(pattern)
+      else if vimState.searchHistory?
+        #vim-mode-plus
+        vimState.searchHistory.save(pattern)
 
     try
       flagsObj = {}

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -339,7 +339,7 @@ class Ex
         # vim-mode
         pattern = vimState.getSearchHistoryItem()
       else if vimState.searchHistory?
-        #vim-mode-plus
+        # vim-mode-plus
         pattern = vimState.searchHistory.get('prev')
 
       if not pattern?
@@ -350,7 +350,7 @@ class Ex
         # vim-mode
         vimState.pushSearchHistory(pattern)
       else if vimState.searchHistory?
-        #vim-mode-plus
+        # vim-mode-plus
         vimState.searchHistory.save(pattern)
 
     try

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "consumedServices": {
     "vim-mode": {
       "versions": {
-        "^0.1.0": "_consumeVim"
+        "^0.1.0": "consumeVim"
       }
     },
     "vim-mode-plus": {
       "versions": {
-        "^0.1.0": "consumeVim"
+        "^0.1.0": "consumeVimModePlus"
       }
     }
   },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,11 @@
   "consumedServices": {
     "vim-mode": {
       "versions": {
+        "^0.1.0": "_consumeVim"
+      }
+    },
+    "vim-mode-plus": {
+      "versions": {
         "^0.1.0": "consumeVim"
       }
     }


### PR DESCRIPTION
Fixes # 128.

Changes Proposed in this Pull Request:

- Fix substitute command error in vim-mode-plus
  Error caused by `searchHistory` functions not existing, so I add if statements.

I have written tests for: Nothing
  Sorry, I'm not sure how to test and how to write this test case...