### PR TITLE
add ':' keybinding for vim-mode-plus

### DIFF
--- a/keymaps/ex-mode.cson
+++ b/keymaps/ex-mode.cson
@@ -9,3 +9,6 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor.vim-mode:not(.insert-mode)':
   ':': 'ex-mode:open'
+
+'atom-text-editor.vim-mode-plus.normal-mode':
+  ':': 'ex-mode:open'


### PR DESCRIPTION
This patch just adds a `':'` keymap that works when using vim-mode-plus.