### PR TITLE
Support Promise response in trySave

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -17,8 +17,13 @@ trySave = (func) ->
   deferred = defer()
 
   try
-    func()
-    deferred.resolve()
+    response = func()
+    
+    if response instanceof Promise
+        response.then ->
+            deferred.resolve()
+    else
+        deferred.resolve()
   catch error
     if error.message.endsWith('is a directory')
       atom.notifications.addWarning("Unable to save file: #{error.message}")
@@ -252,7 +257,7 @@ class Ex
     @write(args)
 
   wq: (args) =>
-    @write(args).then => @quit()
+    @write(args).then(=> @quit())
 
   wa: =>
     @wall()


### PR DESCRIPTION
In Atom 1.19, TextBuffer.save returns a Promise. This commit adds
support to catch this and resolve our internal callbacks when promise
resolves.

Fixes #183 

Needs some testing.
