### PR TITLE
Support Ctrl-C to cancel ex-mode

### DIFF
--- a/keymaps/ex-mode.cson
+++ b/keymaps/ex-mode.cson
@@ -9,5 +9,7 @@
 # https://atom.io/docs/latest/advanced/keymaps
 'atom-text-editor.vim-mode-plus:not(.insert-mode)':
   ':': 'ex-mode:open'
+'atom-text-editor.ex-mode-editor':
+  'ctrl-c': 'ex-mode:close'
 'atom-text-editor.vim-mode:not(.insert-mode)':
   ':': 'ex-mode:open'

--- a/lib/ex-normal-mode-input-element.coffee
+++ b/lib/ex-normal-mode-input-element.coffee
@@ -15,7 +15,8 @@ class ExCommandModeInputElement extends HTMLDivElement
       @editorContainer.style.height = "0px"
 
     @editorElement = document.createElement "atom-text-editor"
-    @editorElement.classList.add('editor')
+    @editorElement.classList.add('editor') # Consider this deprecated!
+    @editorElement.classList.add('ex-mode-editor')
     @editorElement.getModel().setMini(true)
     @editorElement.setAttribute('mini', '')
     @editorContainer.appendChild(@editorElement)
@@ -40,6 +41,7 @@ class ExCommandModeInputElement extends HTMLDivElement
 
     atom.commands.add(@editorElement, 'core:confirm', @confirm.bind(this))
     atom.commands.add(@editorElement, 'core:cancel', @cancel.bind(this))
+    atom.commands.add(@editorElement, 'ex-mode:close', @cancel.bind(this))
     atom.commands.add(@editorElement, 'blur', @cancel.bind(this))
 
   backspace: ->


### PR DESCRIPTION
Fixes #94

For changelog:
```md
* Added support for canceling ex-mode with Ctrl-C ([#186](https://github.com/lloeki/ex-mode/pull/186))
```