### PR TITLE
Adds :sort feature

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -440,16 +440,20 @@ class Ex
   sort: ({ range }) =>
     editor = atom.workspace.getActiveTextEditor()
     sortingRange = [[]]
+
+    # If no range is provided, the entire file should be sorted.
     isMultiLine = range[1] - range[0] > 1
     if isMultiLine
       sortingRange = [[range[0], 0], [range[1] + 1, 0]]
     else
       sortingRange = [[0, 0], [editor.getLastBufferRow(), 0]]
 
+    # Store every bufferedRow string in an array.
     textLines = []
     for lineIndex in [sortingRange[0][0]..sortingRange[1][0] - 1]
       textLines.push(editor.lineTextForBufferRow(lineIndex))
 
+    # Sort the array and join them together with newlines for writing back to the file.
     sortedText = _.sortBy(textLines).join('\n') + '\n'
     editor.buffer.setTextInRange(sortingRange, sortedText)
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -133,6 +133,7 @@ class Ex
 
   qall: => @quitall()
 
+
   tabedit: (args) =>
     if args.args.trim() isnt ''
       @edit(args)
@@ -436,5 +437,12 @@ class Ex
           if not optionProcessor?
             throw new CommandError("No such option: #{option}")
           optionProcessor()
+
+  sort: ({ range }) =>
+    range = [[range[0], 0], [range[1] + 1, 0]]
+    editor = atom.workspace.getActiveTextEditor()
+    text = editor.getTextInBufferRange(range)
+    sortedText = _.sortBy(text.split(/\n/)).join('\n')
+    editor.buffer.setTextInRange(range, sortedText)
 
 module.exports = Ex

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -133,7 +133,6 @@ class Ex
 
   qall: => @quitall()
 
-
   tabedit: (args) =>
     if args.args.trim() isnt ''
       @edit(args)

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -438,10 +438,19 @@ class Ex
           optionProcessor()
 
   sort: ({ range }) =>
-    range = [[range[0], 0], [range[1] + 1, 0]]
     editor = atom.workspace.getActiveTextEditor()
-    text = editor.getTextInBufferRange(range)
-    sortedText = _.sortBy(text.split(/\n/)).join('\n')
-    editor.buffer.setTextInRange(range, sortedText)
+    sortingRange = [[]]
+    isMultiLine = range[1] - range[0] > 1
+    if isMultiLine
+      sortingRange = [[range[0], 0], [range[1] + 1, 0]]
+    else
+      sortingRange = [[0, 0], [editor.getLastBufferRow(), 0]]
+
+    textLines = []
+    for lineIndex in [sortingRange[0][0]..sortingRange[1][0] - 1]
+      textLines.push(editor.lineTextForBufferRow(lineIndex))
+
+    sortedText = _.sortBy(textLines).join('\n') + '\n'
+    editor.buffer.setTextInRange(sortingRange, sortedText)
 
 module.exports = Ex

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -983,3 +983,13 @@ describe "the commands", ->
       expect(calls.length).toEqual 2
       expect(calls[0].args[0].range).toEqual [0, 2]
       expect(calls[1].args[0].range).toEqual [3, 3]
+
+  desctibe ':sort', ->
+    beforeEach ->
+      editor.setText('ghi\nabc\njkl\ndef\n')
+      editor.setCursorBufferPosition([0, 0])
+
+    it "sorts entire file if range is not multi-line", ->
+      openEx()
+      submitNormalModeInputText('sort')
+      expect(atom.getText()).toEqual('abc\ndef\nghi\njkl\n')

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -984,12 +984,17 @@ describe "the commands", ->
       expect(calls[0].args[0].range).toEqual [0, 2]
       expect(calls[1].args[0].range).toEqual [3, 3]
 
-  desctibe ':sort', ->
+  describe ':sort', ->
     beforeEach ->
-      editor.setText('ghi\nabc\njkl\ndef\n')
+      editor.setText('ghi\nabc\njkl\ndef\n142\nzzz\n91xfds9\n')
       editor.setCursorBufferPosition([0, 0])
 
     it "sorts entire file if range is not multi-line", ->
       openEx()
       submitNormalModeInputText('sort')
-      expect(atom.getText()).toEqual('abc\ndef\nghi\njkl\n')
+      expect(editor.getText()).toEqual('142\n91xfds9\nabc\ndef\nghi\njkl\nzzz\n')
+
+    it "sorts specific range if range is multi-line", ->
+      openEx()
+      submitNormalModeInputText('2,4sort')
+      expect(editor.getText()).toEqual('ghi\nabc\ndef\njkl\n142\nzzz\n91xfds9\n')


### PR DESCRIPTION
Changes Proposed in this Pull Request:

- Adds the ability to do :sort in ex-mode in the same way as is done in vanilla vim
- If a range is provided, the lines in the range will be sorted
- If no range is provided, all buffered lines will be sorted

I have written tests for:

- :sort
- :\<range\>sort