### PR TITLE
Support Ctrl-[ to close ex-mode

### DIFF
--- a/keymaps/ex-mode.cson
+++ b/keymaps/ex-mode.cson
@@ -11,5 +11,6 @@
   ':': 'ex-mode:open'
 'atom-text-editor.ex-mode-editor':
   'ctrl-c': 'ex-mode:close'
+  'ctrl-[': 'ex-mode:close'
 'atom-text-editor.vim-mode:not(.insert-mode)':
   ':': 'ex-mode:open'


### PR DESCRIPTION
Changes Proposed in this Pull Request:
This is merely a suggestion to also default the `ctrl-[` keymap to close ex-mode. This is in addition to the [recent addition of `ctrl-c`](https://github.com/lloeki/ex-mode/pull/186). 
(`vim-mode-plus` also supports `ctrl-[` to exit by default)

This behaviour is very similar to vim's default behaviour:
```
CTRL-[          *c_CTRL-[* *c_<Esc>* *c_Esc*
<Esc>		When typed and 'x' not present in 'cpoptions', quit
		Command-line mode without executing.  In macros or when 'x'
		present in 'cpoptions', start entered command.
		Note: If your <Esc> key is hard to hit on your keyboard, train
		yourself to use CTRL-[.
```

Is very similar to the currently supported `ctrl-c`

```
CTRL-C          *c_CTRL-C*
                quit command-line without executing
```