### PR TITLE
Only close buffers on quitall

### DIFF
--- a/lib/ex-mode.coffee
+++ b/lib/ex-mode.coffee
@@ -55,3 +55,8 @@ module.exports = ExMode =
       description: 'When on, the ":substitute" flag \'g\' is default on'
       type: 'boolean'
       default: 'false'
+    onlyCloseBuffers:
+      title: 'Only close buffers'
+      description: 'When on, quitall only closes all buffers, not entire Atom instance'
+      type: 'boolean'
+      default: 'false'

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -132,7 +132,11 @@ class Ex
     atom.workspace.getActivePane().destroyActiveItem()
 
   quitall: ->
-    atom.close()
+    if !atom.config.get('ex-mode.onlyCloseBuffers')
+      atom.close()
+    else
+      atom.workspace.getTextEditors().forEach (editor) ->
+        editor.destroy()
 
   q: => @quit()
 


### PR DESCRIPTION
Every time I use `:qall` it drives me nuts because it closes Atom instead of closing all the editor buffers... so I implemented an option for it.

Might also be good to implement an option for `qall == 'close all panes'`