### PR TITLE
[needs tests] Adjust range behavior

### DIFF
--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -193,6 +193,8 @@ class Command
       if runOverSelections
         for id, selection of @selections
           bufferRange = selection.getBufferRange()
+          if @editor.getTextInBufferRange(bufferRange).endsWith('\n')
+            bufferRange.end.row--
           range = [bufferRange.start.row, bufferRange.end.row]
           func({ range, args, @vimState, @exState, @editor })
       else

--- a/lib/command.coffee
+++ b/lib/command.coffee
@@ -128,11 +128,13 @@ class Command
         if off1?
           address1 += @parseOffset(off1)
 
-        address1 = 0 if address1 is -1
-        address1 = lastLine if address1 > lastLine
+        inputIsNumber = /^\d+$/.test(cl)
 
-        if address1 < 0
-          throw new CommandError('Invalid range')
+        address1 = 0 if address1 is -1
+        address1 = lastLine if address1 > lastLine and inputIsNumber
+
+        if address1 < 0 or address1 > lastLine
+          throw new CommandError('E16: Invalid range')
 
         if addr2?
           address2 = @parseAddr(addr2, cursor)
@@ -140,10 +142,10 @@ class Command
           address2 += @parseOffset(off2)
 
         address2 = 0 if address2 is -1
-        address2 = lastLine if address2 > lastLine
+        address2 = lastLine if address2 > lastLine and inputIsNumber
 
-        if address2 < 0
-          throw new CommandError('Invalid range')
+        if address2 < 0 or address2 > lastLine
+          throw new CommandError('E16: Invalid range')
 
         if address2 < address1
           throw new CommandError('Backwards range given')


### PR DESCRIPTION
Changes Proposed in this Pull Request:

- Throw an error when a provided range, in conjunction with a command, is outside the current file's line boundary
- Fix visually selected range to behave like vim (previously off-by-one)

I'm not sure where I'd put tests for this.

@jazzpi 
