### PR TITLE
Fix :enew not working

### DIFF
--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -3,6 +3,7 @@ CommandError = require './command-error'
 fs = require 'fs-plus'
 VimOption = require './vim-option'
 _ = require 'underscore-plus'
+atom
 
 defer = () ->
   deferred = {}
@@ -210,9 +211,7 @@ class Ex
   e: (args) => @edit(args)
 
   enew: ->
-    buffer = atom.workspace.getActiveTextEditor().buffer
-    buffer.setPath(undefined)
-    buffer.load()
+    atom.workspace.open()
 
   write: ({ range, args, editor, saveas }) ->
     saveas ?= false


### PR DESCRIPTION
Fixes #214 

The previous method used to create a new empty text buffer stopped working with atom 1.19.0. This changes the calls to simply use `atom.workspace.open()`. As [documented](https://atom.io/docs/api/v1.27.1/Workspace#instance-open), it will create a new TextBuffer if called without arguments.
