### PR TITLE
Add more tab commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,26 +36,28 @@ This is the baseline list of commands supported in `ex-mode`.
 
 | Command                                 | Operation                          |
 | --------------------------------------- | ---------------------------------- |
-| `q/quit/tabc/tabclose`                    | Close active tab                   |
-| `qall/quitall`                            | Close all tabs                     |
-| `tabe/tabedit/tabnew`                     | Open new tab                       |
-| `e/edit/tabe/tabedit/tabnew <file>` | Edit given file                    |
-| `tabn/tabnext`                            | Go to next tab                     |
-| `tabp/tabprevious`                        | Go to previous tab                 |
-| `tabo/tabonly`                            | Close other tabs                   |
-| `w/write`                                 | Save active tab                    |
-| `w/write/saveas <file>`             | Save as                            |
-| `wall/wa`                                 | Save all tabs                      |
-| `sp/split`                                | Split window                       |
-| `sp/split <file>`                   | Open file in split window          |
-| `s/substitute`                            | Substitute regular expression in active line                                  |
-| `vsp/vsplit`                              | Vertical split window              |
-| `vsp/vsplit <file>`                 | Open file in vertical split window |
-| `delete`                                  | Cut active line                    |
-| `yank`                                    | Copy active line                   |
-| `set <options>`                     | Set options                        |
-| `sort`                                    | Sort all lines in file             |
-| `sort <line range>`                 | Sort lines in line range           |
+| `q/quit/tabc/tabclose`                  | Close active tab                   |
+| `qall/quitall`                          | Close all tabs                     |
+| `tabe/tabedit/tabnew`                   | Open new tab                       |
+| `e/edit/tabe/tabedit/tabnew <file>`     | Edit given file                    |
+| `tabn/tabnext`                          | Go to next tab                     |
+| `tabp/tabprevious`                      | Go to previous tab                 |
+| `tabfir/tabfirst/tabr/tabrewind`        | Go to the first tab                |
+| `tabl/tablast`                          | Go to the last tab                 |
+| `tabo/tabonly`                          | Close other tabs                   |
+| `w/write`                               | Save active tab                    |
+| `w/write/saveas <file>`                 | Save as                            |
+| `wall/wa`                               | Save all tabs                      |
+| `sp/split`                              | Split window                       |
+| `sp/split <file>`                       | Open file in split window          |
+| `s/substitute`                          | Substitute regular expression in active line |
+| `vsp/vsplit`                            | Vertical split window              |
+| `vsp/vsplit <file>`                     | Open file in vertical split window |
+| `delete`                                | Cut active line                    |
+| `yank`                                  | Copy active line                   |
+| `set <options>`                         | Set options                        |
+| `sort`                                  | Sort all lines in file             |
+| `sort <line range>`                     | Sort lines in line range           |
 
 See `lib/ex.coffee` for the implementations of these commands. Contributions are very welcome!
 

--- a/lib/ex.coffee
+++ b/lib/ex.coffee
@@ -173,6 +173,23 @@ class Ex
 
   tabp: => @tabprevious()
 
+  tabrewind: ->
+    pane = atom.workspace.getActivePane()
+    pane.activateItemAtIndex(0)
+
+  tabr: => @tabrewind()
+
+  tabfirst: => @tabrewind()
+
+  tabfir: => @tabrewind()
+
+  tablast: ->
+    pane = atom.workspace.getActivePane()
+    index = pane.getItems().length - 1
+    pane.activateItemAtIndex(index)
+
+  tabl: => @tablast()
+
   tabonly: ->
     tabBar = atom.workspace.getPanes()[0]
     tabBarElement = atom.views.getView(tabBar).querySelector(".tab-bar")

--- a/spec/ex-commands-spec.coffee
+++ b/spec/ex-commands-spec.coffee
@@ -444,6 +444,34 @@ describe "the commands", ->
       submitNormalModeInputText('tabprevious')
       expect(pane.getActiveItemIndex()).toBe(pane.getItems().length - 1)
 
+  describe ":tabfirst", ->
+    pane = null
+    beforeEach ->
+      waitsForPromise ->
+        pane = atom.workspace.getActivePane()
+        atom.workspace.open().then -> atom.workspace.open()
+          .then -> atom.workspace.open()
+
+    it "switches to the first tab", ->
+      pane.activateItemAtIndex(2)
+      openEx()
+      submitNormalModeInputText('tabfirst')
+      expect(pane.getActiveItemIndex()).toBe(0)
+
+  describe ":tablast", ->
+    pane = null
+    beforeEach ->
+      waitsForPromise ->
+        pane = atom.workspace.getActivePane()
+        atom.workspace.open().then -> atom.workspace.open()
+          .then -> atom.workspace.open()
+
+    it "switches to the last tab", ->
+      pane.activateItemAtIndex(0)
+      openEx()
+      submitNormalModeInputText('tablast')
+      expect(pane.getActiveItemIndex()).toBe(2)
+
   describe ":wq", ->
     beforeEach ->
       spyOn(Ex, 'write').andCallThrough()


### PR DESCRIPTION
This adds two new tab commands: tabr/tabrewind/tabfi/tabfirst and tabl/tablast. These take you to the first and last tab, respectively.

Changes Proposed in this Pull Request:

- Add `:tabrewind` command that takes you to the first tab in the pane
- Add `:tablast` command that takes you to the last tab in the pane
- Add `:tabr`, `:tabfir`, `:tabfirst` as aliases to `:tabrewind` (to match vim)
- Add `:tabl` as an alias to `:tablast` (to match vim)

I have written tests for:

- New features introduced)

However, I was not able to run tests on my laptop (Fedora), it just popped open a bunch of File Open dialogs and failed random tests. I'm hoping that you have CI on this repo or can get it running on your own :(
